### PR TITLE
override home page components

### DIFF
--- a/demo-invenioils/ui/package.json
+++ b/demo-invenioils/ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@inveniosoftware/react-invenio-app-ils": "^1.0.0-alpha.72",
+    "@inveniosoftware/react-invenio-app-ils": "^1.0.0-alpha.75",
     "@rjsf/core": "^2.5.0",
     "@rjsf/semantic-ui": "^2.5.0",
     "axios": "^0.21.0",

--- a/demo-invenioils/ui/src/index.js
+++ b/demo-invenioils/ui/src/index.js
@@ -11,10 +11,10 @@ import { OverridableContext } from 'react-overridable';
 import { Router } from 'react-router-dom';
 import 'semantic-ui-less/semantic.less';
 import { config } from './config';
+import { overriddenCmps } from './overridableMapping';
 
 // Checks if browser is IE (unsupported)
 const isIE = !!document.documentMode;
-const overriddenCmps = {};
 
 if (!isIE) {
   ReactDOM.render(

--- a/demo-invenioils/ui/src/overridableMapping.js
+++ b/demo-invenioils/ui/src/overridableMapping.js
@@ -1,0 +1,7 @@
+import { ServicesInstallationSections } from './overridden/frontsite/Home/Sections/ServicesInstallationSections';
+import { SectionDocsAndUsage } from './overridden/frontsite/Home/Sections/SectionDocsAndUsage';
+
+export const overriddenCmps = {
+  'SectionsWrapper.servicesInstallationSections': ServicesInstallationSections,
+  'SectionInstallation.layout': SectionDocsAndUsage,
+};

--- a/demo-invenioils/ui/src/overridden/frontsite/Home/Sections/SectionDocsAndUsage.js
+++ b/demo-invenioils/ui/src/overridden/frontsite/Home/Sections/SectionDocsAndUsage.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Card, Container, Header, Label, List, Grid } from 'semantic-ui-react';
+
+export const SectionDocsAndUsage = () => {
+  return (
+    <Container fluid className="dot-background-container">
+      <Container fluid className="dot-background">
+        <Container className="fs-landing-page-section">
+          <Header
+            as="h1"
+            className="section-header highlight"
+            textAlign="center"
+          >
+            Documentation and usage
+          </Header>
+          <Grid centered stackable>
+            <Grid.Row>
+              <Grid.Column width={12}>
+                <Card.Group itemsPerRow={2} stackable className="install-cards">
+                  <Card color="orange" className="install-card">
+                    <Card.Content>
+                      <Header size="medium">
+                        <Label circular size="huge" color="orange">
+                          1
+                        </Label>{' '}
+                        Test ILS demo instance
+                      </Header>
+                      <Card.Description textAlign="left">
+                        <List>
+                          <List.Item className="install-item">
+                            <List relaxed>
+                              <List.Item className="install-item">
+                                As a patron by logging in with
+                                <List>
+                                  <List.Item>
+                                    <List.Header>
+                                      email: patron1@test.ch
+                                    </List.Header>
+                                  </List.Item>
+                                  <List.Item>
+                                    <List.Header>password: 123456</List.Header>
+                                  </List.Item>
+                                </List>
+                              </List.Item>
+                              <List.Item className="install-item">
+                                As a librarian by logging in with
+                                <List>
+                                  <List.Item>
+                                    <List.Header>
+                                      email: librarian@test.ch
+                                    </List.Header>
+                                  </List.Item>
+                                  <List.Item>
+                                    <List.Header>password: 123456</List.Header>
+                                  </List.Item>
+                                </List>
+                              </List.Item>
+                              <List.Item className="install-item">
+                                As an admin by logging in with
+                                <List>
+                                  <List.Item>
+                                    <List.Header>
+                                      email: admin@test.ch
+                                    </List.Header>
+                                  </List.Item>
+                                  <List.Item>
+                                    <List.Header>password: 123456</List.Header>
+                                  </List.Item>
+                                </List>
+                              </List.Item>
+                              <List.Item className="install-item">
+                                <List.Header>Note:</List.Header>
+                                <List>
+                                  <List.Item>
+                                    Email sending functionality is disabled for
+                                    the demo instance.
+                                  </List.Item>
+                                  <List.Item>
+                                    The demo data will be recreated
+                                    periodically.
+                                  </List.Item>
+                                </List>
+                              </List.Item>
+                            </List>
+                          </List.Item>
+                        </List>
+                      </Card.Description>
+                    </Card.Content>
+                  </Card>
+                  <Card color="orange" className="install-card">
+                    <Card.Content>
+                      <Header size="medium">
+                        <Label circular size="huge" color="orange">
+                          2
+                        </Label>{' '}
+                        Checkout docs and code
+                      </Header>
+                      <Card.Description textAlign="left">
+                        <List>
+                          <List.Item className="install-item">
+                            InvenioILS{' '}
+                            <a href="https://invenioils.docs.cern.ch/">
+                              documentation
+                            </a>
+                            .
+                          </List.Item>
+                          <List.Item className="install-item">
+                            InvenioILS{' '}
+                            <a href="https://github.com/inveniosoftware/invenio-app-ils">
+                              backend source code
+                            </a>
+                            .
+                          </List.Item>
+                          <List.Item className="install-item">
+                            InvenioILS{' '}
+                            <a href="https://github.com/inveniosoftware/react-invenio-app-ils">
+                              frontend source code
+                            </a>
+                            .
+                          </List.Item>
+                        </List>
+                      </Card.Description>
+                    </Card.Content>
+                  </Card>
+                </Card.Group>
+              </Grid.Column>
+            </Grid.Row>
+          </Grid>
+        </Container>
+      </Container>
+    </Container>
+  );
+};

--- a/demo-invenioils/ui/src/overridden/frontsite/Home/Sections/ServicesInstallationSections.js
+++ b/demo-invenioils/ui/src/overridden/frontsite/Home/Sections/ServicesInstallationSections.js
@@ -1,0 +1,14 @@
+import {
+  SectionServices,
+  SectionInstallation,
+} from '@inveniosoftware/react-invenio-app-ils';
+import React from 'react';
+
+export const ServicesInstallationSections = () => {
+  return (
+    <>
+      <SectionInstallation />
+      <SectionServices />
+    </>
+  );
+};


### PR DESCRIPTION
* swap 'Our services' and 'Installation sections'
* remove back and frontend installation instructions
* add card with links to the docs and source code
* remove 'Docs', 'Code' and 'UI Code' buttons from the 'Installation' section
* add note for disabled email sending throughout the site
* closes https://github.com/inveniosoftware/demo-invenioils/issues/4

Result previews in desktop and mobile views
![Screenshot 2022-11-14 at 13 30 06](https://user-images.githubusercontent.com/61321254/201660453-184eb02b-6069-4ab2-a257-3dc89627dcb8.png)


![Screenshot 2022-11-14 at 13 30 45](https://user-images.githubusercontent.com/61321254/201660531-1c3d8eff-84ac-475b-94a1-d6052c251ca5.png)

